### PR TITLE
Added analysis engine (with file type check)

### DIFF
--- a/1.0.0/music-analyzer.psm1
+++ b/1.0.0/music-analyzer.psm1
@@ -12,9 +12,10 @@ $global:Emojis = @{
 
 # PRIVATE FUNCTIONS
 . $PSScriptRoot\private\AutoAnalyzeFiles.ps1
+. $PSScriptRoot\private\CheckFileType.ps1
+. $PSScriptRoot\private\GetVolumeInfo.ps1
 . $PSScriptRoot\private\Helpers.ps1
 . $PSScriptRoot\private\Outputs.ps1
-. $PSScriptRoot\private\GetVolumeInfo.ps1
 
 # PUBLIC FUNCTIONS
 . $PSScriptRoot\public\MusicAnalyzer.ps1

--- a/1.0.0/music-analyzer.psm1
+++ b/1.0.0/music-analyzer.psm1
@@ -14,6 +14,7 @@ $global:Emojis = @{
 . $PSScriptRoot\private\AutoAnalyzeFiles.ps1
 . $PSScriptRoot\private\Helpers.ps1
 . $PSScriptRoot\private\Outputs.ps1
+. $PSScriptRoot\private\GetVolumeInfo.ps1
 
 # PUBLIC FUNCTIONS
 . $PSScriptRoot\public\MusicAnalyzer.ps1

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -42,6 +42,7 @@ function AutoAnalyzeFiles {
     $fileCompleted += 1
     Write-Progress -Activity $activity -PercentComplete $progress -CurrentOperation "Analyzing $($currentFile.name).$($currentFile.extension) ..." -Status "$($barStatus)"
     Write-Host " $($fileCompleted)/$($fileNumber) | $($status) | $($currentFile.name).$($currentFile.extension) " -Background Yellow -Foreground Black
+    $output = Get-VolumeInfo $currentFile # Type: System.Object[]
     Write-Host ""
   }
 }

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -42,7 +42,8 @@ function AutoAnalyzeFiles {
     $fileCompleted += 1
     Write-Progress -Activity $activity -PercentComplete $progress -CurrentOperation "Analyzing $($currentFile.name).$($currentFile.extension) ..." -Status "$($barStatus)"
     Write-Host " $($fileCompleted)/$($fileNumber) | $($status) | $($currentFile.name).$($currentFile.extension) " -Background Yellow -Foreground Black
-    $output = Get-VolumeInfo $currentFile # Type: System.Object[]
+    $maxVolume = Get-VolumeInfo $currentFile
+    Write-Host $maxVolume
     Write-Host ""
   }
 }

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -43,13 +43,21 @@ function AutoAnalyzeFiles {
     Write-Progress -Activity $activity -PercentComplete $progress -CurrentOperation "Analyzing $($currentFile.name).$($currentFile.extension) ..." -Status "$($barStatus)"
     Write-Host " $($fileCompleted)/$($fileNumber) | $($status) | $($currentFile.name).$($currentFile.extension) " -Background Yellow -Foreground Black
 
-    $maxVolume = Get-VolumeInfo $currentFile
-    if ($maxVolume -ne 0) {
-      OutputVolumeAnalysis "adjustmentNeeded" $maxVolume
+    if ( (CheckFileType $currentFile) -eq 'Supported' ) {
+      $maxVolume = Get-VolumeInfo $currentFile
+      if ($maxVolume -ne 0) {
+        OutputVolumeAnalysis "adjustmentNeeded" $maxVolume
+      }
+      else {
+        OutputVolumeAnalysis "noAdjustment"      
+      }
     }
     else {
-      OutputVolumeAnalysis "noAdjustment"      
+      # File probably not supported
+      OutputCheckFileType "unsupported"
     }
+
+    
     Write-Host ""
   }
 }

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -42,8 +42,14 @@ function AutoAnalyzeFiles {
     $fileCompleted += 1
     Write-Progress -Activity $activity -PercentComplete $progress -CurrentOperation "Analyzing $($currentFile.name).$($currentFile.extension) ..." -Status "$($barStatus)"
     Write-Host " $($fileCompleted)/$($fileNumber) | $($status) | $($currentFile.name).$($currentFile.extension) " -Background Yellow -Foreground Black
+
     $maxVolume = Get-VolumeInfo $currentFile
-    Write-Host $maxVolume
+    if ($maxVolume -ne 0) {
+      OutputVolumeAnalysis "adjustmentNeeded" $maxVolume
+    }
+    else {
+      OutputVolumeAnalysis "noAdjustment"      
+    }
     Write-Host ""
   }
 }

--- a/1.0.0/private/CheckFileType.ps1
+++ b/1.0.0/private/CheckFileType.ps1
@@ -1,0 +1,28 @@
+function CheckFileType {
+  <#
+    .SYNOPSIS
+      Analyze the file type based on its extension and return the correct operation to make for the MusicAnalyzer main function
+      - 'Supported' -> Means that the extension is supported
+      - 'Unsupported' -> Meanse that the extension is not supported
+    
+    .PARAMETER inputFile
+      Required. Complete file object to analyze.
+  #>
+
+  [CmdletBinding(DefaultParameterSetName)]
+  param (
+    [Parameter(Mandatory = $true)]
+    $inputFile
+  )
+
+  $returnValue = "Unsupported"
+
+  # Define array of supported extensions
+  $supportedExtensions = @("mp3", "MP3")
+
+  if ( $supportedExtensions.Contains( $inputFile.extension )) {
+    $returnValue = 'Supported'
+  }
+
+  return $returnValue
+}

--- a/1.0.0/private/GetVolumeInfo.ps1
+++ b/1.0.0/private/GetVolumeInfo.ps1
@@ -1,0 +1,26 @@
+function Get-VolumeInfo {
+  <#
+    .SYNOPSIS
+      Get the volume info from the specified file
+    
+    .EXAMPLE
+      Get-VolumeInfo $file
+    
+    .PARAMETER inputFile
+      Required. Complete file object to analyze.
+  #>
+
+  [CmdLetBinding(DefaultParameterSetName)]
+  Param (
+    [Parameter(Mandatory = $true)]
+    $inputFile
+  )
+
+  # ffmpeg output is in StandardError feed, when no output is specified like in this case.
+  # For this reason I added 2>&1 to redirect StdErr to StdOut and save the output in a
+  # variable. This variable is a "forced" [array].
+  # No output will be visible to the user side, but I must then parse it.
+  [array] $returnValues = ffmpeg -i $inputFile.fullFilePath -filter:a volumedetect -f null /dev/null 2>&1
+
+  return $returnValues
+}

--- a/1.0.0/private/GetVolumeInfo.ps1
+++ b/1.0.0/private/GetVolumeInfo.ps1
@@ -20,7 +20,20 @@ function Get-VolumeInfo {
   # For this reason I added 2>&1 to redirect StdErr to StdOut and save the output in a
   # variable. This variable is a "forced" [array].
   # No output will be visible to the user side, but I must then parse it.
-  [array] $returnValues = ffmpeg -i $inputFile.fullFilePath -filter:a volumedetect -f null /dev/null 2>&1
+  $params = @(
+    "-i", $inputFile.fullFilePath,
+    "-filter:a", "volumedetect",
+    "-f", "null", "/dev/null"
+  )
+  $ffmpegOutput = ffmpeg $params 2>&1
 
-  return $returnValues
+  $regEx = "max_volume: ([+-])(\d*[.]\d) dB"
+  $maxVolumeString = $ffmpegOutput | Select-String -Pattern "max_volume:"
+  $maxVolume = 0
+  if ( $maxVolumeString ) {
+    # Returns positive or negative
+    $maxVolume = [Float](([regex]::Matches($maxVolumeString, $regEx)).Groups[1].Value.trim() + ([regex]::Matches($maxVolumeString, $regEx)).Groups[2].Value.trim())
+  }
+
+  return $maxVolume
 }

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -49,3 +49,20 @@ function OutputUserError {
     Default {}
   }
 }
+
+function OutputVolumeAnalysis {
+  [CmdletBinding(DefaultParameterSetName)]
+  param (
+    [Parameter(Mandatory = $true)]
+    [String]$Value,
+
+    [Parameter(Mandatory = $false)]
+    [String]$Volume
+  )
+
+  switch ($Value) {
+    'noAdjustment' { Write-Host " $($Emojis["check"]) Max volume at 0 dB" }
+    'adjustmentNeeded' { Write-Host " $($Emojis["warning"]) Max volume is $($Volume) dB, volume normalization needed..." }
+    Default {}
+  }
+}

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -66,3 +66,16 @@ function OutputVolumeAnalysis {
     Default {}
   }
 }
+
+function OutputCheckFileType {
+  [CmdletBinding()]
+  param (
+    [Parameter(Mandatory = $true)]
+    [String]$Value
+  )
+
+  switch ($Value) {
+    'unsupported' { Write-Host " $($Emojis["ban"]) File not supported" }
+    Default {}
+  }
+}


### PR DESCRIPTION
Using **ffmpeg** `volumedetect` filter with no output file specified, we can detect the `max_volume` of the audio track.

Before this analysis, we check for the file extension. If it is supported, we can analyze it.

This `max_volume` will be later used to correct volume through a simple normalization.