### PR TITLE
Renaming after normalizing

### DIFF
--- a/1.0.0/private/NormalizeVolume.ps1
+++ b/1.0.0/private/NormalizeVolume.ps1
@@ -22,9 +22,10 @@ function NormalizeVolume {
     [Float]$maxVolume
   )
 
+  # Build output file object
   $outputSuffix = "_norm"
   $outputFile = @{
-    fullFilePath = $inputFile.path + "\" + $inputFile.name + $outputSuffix + "." + $inputFile.extension
+    fullFilePath = "$($inputFile.path)\$($inputFile.name)$($outputSuffix).$($inputFile.extension)"
     path         = $inputFile.path
     name         = $inputFile.name + $outputSuffix
     extension    = $inputFile.extension
@@ -33,7 +34,7 @@ function NormalizeVolume {
   # Check if outputfile already exists
   $i = 0
   while (Test-Path -path $outputFile.fullFilePath) {
-    # Output fileName already exist, increment CopyNum
+    # Output file already exist, increment CopyNum
     $i += 1
     $copyNum = '{0:d3}' -f $i
     $newOutputFilename = "$($inputFile.name + $outputSuffix)+$($copyNum)"
@@ -52,4 +53,30 @@ function NormalizeVolume {
   # 2> $null is to cutoff output
   OutputVolumeAnalysis 'normalizing' $inputFile.name
   ffmpeg $params 2> $null
+
+  # Build backup file object
+  $backupSuffix = "backup"
+  $backupFile = @{
+    fullFilePath = "$($inputFile.path)\$($inputFile.name).$($inputFile.extension).$($backupSuffix)"
+    path         = $inputFile.path
+    name         = "$($inputFile.name).$($inputFile.extension)"
+    extension    = $backupSuffix
+  }
+  
+  # Check if backup file already exist
+  $i = 0
+  while (Test-Path -path $backupFile.fullFilePath) {
+    # Backup file already exist, increment CopyNum
+    $i += 1
+    $copyNum = '{0:d3}' -f $i
+    $newBackupFilename = "$($inputFile.name).$($inputFile.extension)+$($copyNum)"
+    $backupFile.fullFilePath = "$($backupFile.path)\$($newBackupFilename).$($backupSuffix)"
+    $backupFile.name = $newBackupFilename
+  }
+
+  # Rename original file to create a backup
+  Rename-Item -Path $inputFile.fullFilePath -NewName "$($backupFile.name).$($backupFile.extension)"
+
+  # Rename output file to input file
+  Rename-Item -Path $outputFile.fullFilePath -NewName "$($inputFile.name).$($inputFile.extension)"
 }


### PR DESCRIPTION
Now the script makes some renaming after normalizing.
The input file will be renamed, adding a `.backup` extension.
The output file will be then renamed as the input file.