### PR TITLE
Bugfix: reset workingFolder global variable

### DIFF
--- a/1.0.0/public/MusicAnalyzer.ps1
+++ b/1.0.0/public/MusicAnalyzer.ps1
@@ -11,4 +11,7 @@ Function MusicAnalyzer {
   OutputSpacer
   AutoAnalyzeFiles $workingFolder
   OutputScriptFooter
+
+  # Delete workingFolder global variable
+  $WorkingFolder = ""
 }


### PR DESCRIPTION
When the script ends, it should reset the `workingFolder` global variable, to avoid issues with further executions of the script in the same Powershell session.