### PR TITLE
CleanBackups function added

### DIFF
--- a/1.0.0/music-analyzer.psm1
+++ b/1.0.0/music-analyzer.psm1
@@ -13,6 +13,7 @@ $global:Emojis = @{
 # PRIVATE FUNCTIONS
 . $PSScriptRoot\private\AutoAnalyzeFiles.ps1
 . $PSScriptRoot\private\CheckFileType.ps1
+. $PSScriptRoot\private\CleanBackups.ps1
 . $PSScriptRoot\private\GetVolumeInfo.ps1
 . $PSScriptRoot\private\Helpers.ps1
 . $PSScriptRoot\private\NormalizeVolume.ps1

--- a/1.0.0/music-analyzer.psm1
+++ b/1.0.0/music-analyzer.psm1
@@ -8,7 +8,7 @@ $global:Emojis = @{
   "ban"      = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("26D4", 16))
   "info"     = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F7E6", 16))
   "pen"      = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F4DD", 16))
-  "time"     = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F551", 16))
+  "delete"   = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("274C", 16))
   "volume"   = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F509", 16))
   "question" = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("2753", 16))
 }

--- a/1.0.0/music-analyzer.psm1
+++ b/1.0.0/music-analyzer.psm1
@@ -1,9 +1,12 @@
 $global:Emojis = @{
+  # Emoji list
+  # https://unicode.org/emoji/charts/full-emoji-list.html
+  #
   "check"    = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("2705", 16))
   "error"    = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F534", 16))
   "warning"  = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F7E8", 16))
   "ban"      = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("26D4", 16))
-  "calendar" = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F4C6", 16))
+  "info"     = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F7E6", 16))
   "pen"      = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F4DD", 16))
   "time"     = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F551", 16))
   "volume"   = [System.Char]::ConvertFromUtf32([System.Convert]::toInt32("1F509", 16))

--- a/1.0.0/private/CleanBackups.ps1
+++ b/1.0.0/private/CleanBackups.ps1
@@ -7,5 +7,20 @@ function CleanBackups {
       Optional. The folder to scan and to clean. By default it uses the passed path, if present, otherwise it will ask the user.
   #>
 
-  Write-Host "It works!"
+  [CmdletBinding(DefaultParameterSetName)]
+  param (
+    [Parameter(Mandatory = $false)]
+    [String]
+    $workingFolder
+  )
+
+  # Analyze and set the workingFolder
+  if ($workingFolder -ne "") {
+    # Global working folder is set - i.E. after normal workflow of analyzing
+    Write-Host "Found a global working folder"
+  }
+  else {
+    # No global specified, ask the user
+    Write-Host "Ask the user"
+  }
 }

--- a/1.0.0/private/CleanBackups.ps1
+++ b/1.0.0/private/CleanBackups.ps1
@@ -21,9 +21,7 @@ function CleanBackups {
     $userChoice = Read-Host "$($Emojis["question"]) Would you like to delete *.backup files? [s/n]"
     switch ($userChoice) {
       's' { CleanFiles $workingFolder }
-      'n' {
-        Read-Host " >> Ok, press enter to exit"
-      }
+      'n' { Read-Host " >> Ok, press enter to exit" }
       Default {
         # False input, do not delete backup files
         OutputUserError "invalidChoice"
@@ -32,7 +30,13 @@ function CleanBackups {
   }
   else {
     # No global specified, ask the user
-    Write-Host "Ask the user"
+    $userPath = Read-Host ">> Please specify the path to clean"
+    if ($userPath -ne "") {
+      $userPath = $userPath -replace '["]', ''
+      if (Test-Path -Path "$($userPath)") { CleanFiles $userPath }
+      else { OutputUserError "invalidPath" }
+    }
+    else { OutputUserError "emptyPath" }
   }
 }
 

--- a/1.0.0/private/CleanBackups.ps1
+++ b/1.0.0/private/CleanBackups.ps1
@@ -1,0 +1,11 @@
+function CleanBackups {
+  <#
+    .SYNOPSIS
+      Remove the file generated as backup after normalizing
+    
+    .PARAMETER workingFolder
+      Optional. The folder to scan and to clean. By default it uses the passed path, if present, otherwise it will ask the user.
+  #>
+
+  Write-Host "It works!"
+}

--- a/1.0.0/private/CleanBackups.ps1
+++ b/1.0.0/private/CleanBackups.ps1
@@ -16,11 +16,32 @@ function CleanBackups {
 
   # Analyze and set the workingFolder
   if ($workingFolder -ne "") {
-    # Global working folder is set - i.E. after normal workflow of analyzing
-    Write-Host "Found a global working folder"
+    # Global working folder is passed - i.E. after normal workflow of analyzing
+    # Write-Host "$($Emojis["info"]) $($workingFolder)"
+    $userChoice = Read-Host "$($Emojis["question"]) Would you like to delete *.backup files? [s/n]"
+    switch ($userChoice) {
+      's' { CleanFiles $workingFolder }
+      'n' {
+        Read-Host " >> Ok, press enter to exit"
+      }
+      Default {
+        # False input, do not delete backup files
+        OutputUserError "invalidChoice"
+      }
+    }
   }
   else {
     # No global specified, ask the user
     Write-Host "Ask the user"
   }
+}
+
+function CleanFiles {
+  [CmdLetBinding(DefaultParameterSetName)]
+  Param (
+    [Parameter(Mandatory = $true)]
+    [String]$workingPath
+  )
+
+  Write-Host "It works"
 }

--- a/1.0.0/private/CleanBackups.ps1
+++ b/1.0.0/private/CleanBackups.ps1
@@ -18,7 +18,7 @@ function CleanBackups {
   if ($workingFolder -ne "") {
     # Global working folder is passed - i.E. after normal workflow of analyzing
     # Write-Host "$($Emojis["info"]) $($workingFolder)"
-    $userChoice = Read-Host "$($Emojis["question"]) Would you like to delete *.backup files? [s/n]"
+    $userChoice = Read-Host "$($Emojis["question"]) Would you like to delete *.backup files? All the subdirectories will be also cleaned! [s/n]"
     switch ($userChoice) {
       's' { CleanFiles $workingFolder }
       'n' { Read-Host " >> Ok, press enter to exit" }
@@ -41,11 +41,34 @@ function CleanBackups {
 }
 
 function CleanFiles {
+  <#
+    .SYNOPSIS
+      This function search all the .backup files in the specified folder and its subfolders, then deletes them
+    
+    .PARAMETER workingPath
+      Required. The folder to scan
+  #>
   [CmdLetBinding(DefaultParameterSetName)]
   Param (
     [Parameter(Mandatory = $true)]
     [String]$workingPath
   )
 
-  Write-Host "It works"
+  # Analize provided path
+  $filesToCleanup = Get-ChildItem -Path $workingPath -Filter "*.backup" -Recurse
+  
+  # Initialize file progress bar variables
+  $fileCompleted = 0
+  $fileNumber = $filesToCleanup.Count
+  $activity = "Cleaning up backup files"
+  $activityProgressBar = [ProgressBar]::new($activity, 0, $fileNumber)
+
+  if ( $fileNumber -gt 0 ) {
+    Write-Host "Detected $($fileNumber) files to clean"
+  }
+  else {
+    OutputCleanResult "noFiles"
+  }
+
+  #$activityProgressBar.UpdateProgress("new activity",$fileCompleted)
 }

--- a/1.0.0/private/CleanBackups.ps1
+++ b/1.0.0/private/CleanBackups.ps1
@@ -64,11 +64,25 @@ function CleanFiles {
   $activityProgressBar = [ProgressBar]::new($activity, 0, $fileNumber)
 
   if ( $fileNumber -gt 0 ) {
-    Write-Host "Detected $($fileNumber) files to clean"
+    $filesToCleanup | ForEach-Object {
+      # File object
+      $currentFile = @{
+        fullFilePath = $_.FullName
+        path         = Split-Path -Path $_.FullName -Parent
+        name         = (GetFilename( Split-Path -Path $_.FullName -Leaf)).fileName
+        extension    = (GetFilename( Split-Path -Path $_.FullName -Leaf)).extension
+      }
+
+      # Deleting the file
+      $fileCompleted += 1
+      $activityProgressBar.UpdateProgress("Deleting $($currentFile.name).$($currentFile.extension)", $fileCompleted)
+      Remove-Item $currentFile.fullFilePath
+      OutputCleanResult "deleted" "$($currentFile.name).$($currentFile.extension)"
+    }
+    OutputCleanResult "completed"
   }
   else {
+    # No files found
     OutputCleanResult "noFiles"
   }
-
-  #$activityProgressBar.UpdateProgress("new activity",$fileCompleted)
 }

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -130,3 +130,28 @@ function OutputScriptFooter {
   Write-Host ""
   Write-Host ""
 }
+
+function OutputCleanResult {
+  [CmdLetBinding(DefaultParameterSetName)]
+  Param (
+    [Parameter(Mandatory = $true)]
+    [String]$Value
+  )
+
+  switch ($value) {
+    'completed' {
+      Write-Host ""
+      Write-Host "                               " -BackgroundColor DarkGreen -ForegroundColor White
+      Write-Host "      CLEANING  COMPLETED      " -BackgroundColor DarkGreen -ForegroundColor White
+      Write-Host "                               " -BackgroundColor DarkGreen -ForegroundColor White
+      (New-Object System.Media.SoundPlayer "$env:windir\Media\Alarm03.wav").Play()
+      Write-Host ""
+    }
+    'noFiles' {
+      Write-Host ""
+      Write-Host "        NO FILES FOUND         " -BackgroundColor DarkRed -ForegroundColor White
+      Write-Host ""
+    }
+    Default {}
+  }
+}

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -1,34 +1,56 @@
 Function OutputScriptHeader {
+  [CmdLetBinding(DefaultParameterSetName)]
+  Param (
+    [Parameter(Mandatory = $false)]
+    [String]$Value
+  )
+
   $title = @"
- _____________________________________________________
-|                __  __           _                   |
-|               |  \/  |         (_)                  |
-|               | \  / |_   _ ___ _  ___              |
-|               | |\/| | | | / __| |/ __|             |
-|               | |  | | |_| \__ \ | (__              |
-|               |_|  |_|\__,_|___/_|\___|             |
-|                           _                         |
-|         /\               | |                        |
-|        /  \   _ __   __ _| |_   _ _______ _ __      |
-|       / /\ \ | '_ \ / _' | | | | |_  / _ \ '__|     |
-|      / ____ \| | | | (_| | | |_| |/ /  __/ |        |
-|     /_/    \_\_| |_|\__,_|_|\__, /___\___|_|        |
-|                              __/ |                  |
-|                             |___/                   |
-|                                                     |
-|                                                     |
-|           ~~ Welcome to Music Analzyer ~~           |
-|          A script for music consolidation           |
-|                                                     |
-|                                                     |
-|  Author: Francesco Tili                             |
-|_____________________________________________________|
+ _____________________________________________________________________
+|                        __  __           _                           |
+|                       |  \/  |         (_)                          |
+|                       | \  / |_   _ ___ _  ___                      |
+|                       | |\/| | | | / __| |/ __|                     |
+|                       | |  | | |_| \__ \ | (__                      |
+|                       |_|  |_|\__,_|___/_|\___|                     |
+|                                   _                                 |
+|                 /\               | |                                |
+|                /  \   _ __   __ _| |_   _ _______ _ __              |
+|               / /\ \ | '_ \ / _' | | | | |_  / _ \ '__|             |
+|              / ____ \| | | | (_| | | |_| |/ /  __/ |                |
+|             /_/    \_\_| |_|\__,_|_|\__, /___\___|_|                |
+|                                      __/ |                          |
+|                                     |___/                           |
+|                                                                     |
+|                                                                     |
+|                   ~~ Welcome to Music Analzyer ~~                   |
+|                  A script for music consolidation                   |
+|                                                                     |
+|                                                                     |
+|          Author: Francesco Tili                                     |
+|_____________________________________________________________________|
 "@
 
   for ( $i = 0; $i -lt $title.Length; $i++ ) {
     Write-Host $title[$i] -NoNewline
   }
   Write-Host ""
+  if ($value) {
+    switch ($value) {
+      "CleanBackups" {
+        Write-Host ""
+        Write-Host "This command will scan a specified folder and subfolders for .backup files and it will deleted them."
+        Write-Host "$($Emojis["warning"]) The files will be deleted forever!"
+      }
+      Default {}
+    }
+  }
+  else {
+    Write-Host ""
+    Write-Host "This command will scan a specified folder and subfolders for audio files."
+    Write-Host "The audio files will be analyzed for their volume and then, if needed, normalized."
+    Write-Host "$($Emojis["check"]) Original files will be renamed to .backup"
+  }
   Write-Host ""
 }
 

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -135,7 +135,10 @@ function OutputCleanResult {
   [CmdLetBinding(DefaultParameterSetName)]
   Param (
     [Parameter(Mandatory = $true)]
-    [String]$Value
+    [String]$Value,
+
+    [Parameter(Mandatory = $false)]
+    [String]$fileName
   )
 
   switch ($value) {
@@ -151,6 +154,9 @@ function OutputCleanResult {
       Write-Host ""
       Write-Host "        NO FILES FOUND         " -BackgroundColor DarkRed -ForegroundColor White
       Write-Host ""
+    }
+    'deleted' {
+      Write-Host " $($Emojis["delete"]) Deleting... | $($fileName)" 
     }
     Default {}
   }

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -66,6 +66,7 @@ function OutputUserError {
   )
 
   switch ($Value) {
+    'invalidChoice' { Write-Host " $($Emojis["error"]) Invalid choice!" }
     'invalidPath' { Write-Error -Message " $($Emojis["error"]) Specified path is not valid! Exiting..." -ErrorAction Stop }
     'emptyPath' { Write-Error -Message " $($Emojis["error"]) You have not specified a path. Exiting..." -ErrorAction Stop }
     Default {}

--- a/1.0.0/public/MusicAnalyzer.ps1
+++ b/1.0.0/public/MusicAnalyzer.ps1
@@ -1,14 +1,27 @@
 Function MusicAnalyzer {
-  # Show script header
-  Clear-Host
-  OutputScriptHeader
+  [CmdletBinding(DefaultParameterSetName)]
+  param (
+    [Parameter(Mandatory = $false)]
+    [switch]
+    $cleanBackups = $false
+  )
 
-  Write-Host " >> $($Emojis["warning"]) All changes will be written to files!"
+  if ( $cleanBackups ) {
+    Clear-Host
+    OutputScriptHeader "CleanBackups"
 
-  # Ask for path
-  $WorkingFolder = Set-Path
-  Clear-Host
-  OutputSpacer
-  AutoAnalyzeFiles $workingFolder
-  OutputScriptFooter
+    CleanBackups
+  }
+  else {
+    # Show script header
+    Clear-Host
+    OutputScriptHeader
+
+    # Ask for path
+    $WorkingFolder = Set-Path
+    Clear-Host
+    OutputSpacer
+    AutoAnalyzeFiles $workingFolder
+    OutputScriptFooter
+  }
 }


### PR DESCRIPTION
Use the command `MusicAnalyzer -CleanBackups` to start the cleanBackup workflow.

It will scan the specified path for .backup (also in subfolder) and delete this files.