### PR TITLE
AnalyzeOnly flag added

### DIFF
--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -99,18 +99,22 @@ function AutoAnalyzeFiles {
         OutputVolumeAnalysis "noNormalizing"
       }
       else {
-        foreach ($analysis in $volumeAnalysis) {
-          $fileCompleted += 1
-          $fileProgressBar.UpdateProgress("Normalizing $($analysis.file.name).$($analysis.file.extension)", $fileCompleted)
+        if (-Not $global:AnalyzeOnlyActive) {
+          foreach ($analysis in $volumeAnalysis) {
+            $fileCompleted += 1
+            $fileProgressBar.UpdateProgress("Normalizing $($analysis.file.name).$($analysis.file.extension)", $fileCompleted)
 
-          if ( $analysis.normalize ) {
-            #OutputVolumeAnalysis "normalizing" $analysis.file.name
-            NormalizeVolume $analysis.file $maxVolumeGain
+            if ( $analysis.normalize ) {
+              NormalizeVolume $analysis.file $maxVolumeGain
+            }
+            else {
+              OutputVolumeAnalysis "skipping" $analysis.file.name
+            }
           }
-          else {
-            OutputVolumeAnalysis "skipping" $analysis.file.name
-          }
-        }      
+        }
+        else {
+          OutputVolumeAnalysis "needsNormalizing"
+        }
       }
       Write-Host ""
     }

--- a/1.0.0/private/CleanBackups.ps1
+++ b/1.0.0/private/CleanBackups.ps1
@@ -65,7 +65,7 @@ function CleanFiles {
   $activity = "Cleaning up backup files"
   $activityProgressBar = [ProgressBar]::new($activity, 0, $fileNumber)
 
-  if ( $fileNumber -gt 0 ) {
+  if ((-Not $global:AnalyzeOnlyActive) -and ($fileNumber -gt 0)) {
     $filesToCleanup | ForEach-Object {
       # File object
       $currentFile = @{
@@ -82,6 +82,9 @@ function CleanFiles {
       OutputCleanResult "deleted" "$($currentFile.name).$($currentFile.extension)"
     }
     OutputCleanResult "completed"
+  }
+  elseif ($global:AnalyzeOnlyActive -and ($fileNumber -gt 0)) {
+    OutputCleanResult "files_detected" $fileNumber
   }
   else {
     # No files found

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -198,6 +198,11 @@ function OutputRestoreResult {
       Write-Host "        NO FILES FOUND         " -BackgroundColor DarkRed -ForegroundColor White
       Write-Host ""
     }
+    'files_detected' {
+      Write-Host ""
+      Write-Host "    $($fileName) FILES CAN BE RESTORED   " -BackgroundColor DarkGreen -ForegroundColor White
+      Write-Host ""
+    }
     Default {}
   }
 }

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -159,6 +159,11 @@ function OutputCleanResult {
     'deleted' {
       Write-Host " $($Emojis["delete"]) Deleted | $($fileName)"
     }
+    'files_detected' {
+      Write-Host ""
+      Write-Host "        $($fileName) FILES FOUND         " -BackgroundColor DarkYellow -ForegroundColor White
+      Write-Host ""
+    }
     Default {}
   }
 }

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -103,6 +103,7 @@ function OutputVolumeAnalysis {
     'noAdjustment' { Write-Host (" {0} {1} | {2}" -f $Emojis["check"], $stringVolume, $fileName ) }
     'adjustmentNeeded' { Write-Host (" {0} {1} | {2}" -f $Emojis["warning"], $stringVolume, $fileName ) }
     'noNormalizing' { Write-Host (" $($Emojis["check"]) No need to normalize, max volume is alread 0 dB at the album level") }
+    'needsNormalizing' { Write-Host (" $($Emojis["warning"]) Needs to be normalized at the album level") }
     'normalizing' { Write-Host " $($Emojis["volume"]) Normalizing ...    | $($fileName)" }
     'skipping' { Write-Host " $($Emojis["check"]) Already normalized | $($fileName)" }
     Default {}

--- a/1.0.0/private/RestoreBackups.ps1
+++ b/1.0.0/private/RestoreBackups.ps1
@@ -36,7 +36,7 @@ function RestoreFiles {
   $activity = "Restoring from backup files"
   $activityProgressBar = [ProgressBar]::new($activity, 0, $fileNumber)
 
-  if ( $fileNumber -gt 0 ) {
+  if ((-Not $global:AnalyzeOnlyActive) -and ($fileNumber -gt 0)) {
     $filesToRestore | ForEach-Object {
       # File object
       $currentFile = @{
@@ -59,6 +59,9 @@ function RestoreFiles {
       OutputRestoreResult "backup_restored" "$($currentFile.name)"
     }
     OutputRestoreResult "completed"
+  }
+  elseif ($global:AnalyzeOnlyActive -and ($fileNumber -gt 0)) {
+    OutputRestoreResult "files_detected" $fileNumber
   }
   else {
     # No files found

--- a/1.0.0/public/MusicAnalyzer.ps1
+++ b/1.0.0/public/MusicAnalyzer.ps1
@@ -42,7 +42,6 @@ Function MusicAnalyzer {
       # No parameters specified
       Clear-Host
       OutputScriptHeader
-      Write-Host $analyzeOnly
     
       # Ask for path
       $workingFolder = Set-Path
@@ -52,7 +51,9 @@ Function MusicAnalyzer {
       OutputScriptFooter
 
       # Start cleanup workflow
-      CleanBackups $workingFolder
+      if (-Not $global:AnalyzeOnlyActive) {
+        CleanBackups $workingFolder
+      }
     }
   }
 }

--- a/1.0.0/public/MusicAnalyzer.ps1
+++ b/1.0.0/public/MusicAnalyzer.ps1
@@ -1,4 +1,6 @@
 Function MusicAnalyzer {
+  [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'AnalyzeOnlyActive',
+    Justification = 'Variable is global and used in different scopes')]
   [CmdletBinding()]
   param (
     [Parameter(Mandatory = $false)]
@@ -7,11 +9,18 @@ Function MusicAnalyzer {
 
     [Parameter(Mandatory = $false)]
     [switch]
-    $restoreBackups = $false
+    $restoreBackups = $false,
+
+    [Parameter(Mandatory = $false)]
+    [switch]
+    $analyzeOnly = $false
   )
 
-  $flags = "$($cleanBackups)-$($restoreBackups)"
+  # Global parameters set
+  $global:AnalyzeOnlyActive = $analyzeOnly
 
+  # Flag analysis workflow
+  $flags = "$($cleanBackups)-$($restoreBackups)"
   switch ($flags) {
     "True-True" {
       # Both parameters -cleanBackups and -restoreBackups specified
@@ -33,6 +42,7 @@ Function MusicAnalyzer {
       # No parameters specified
       Clear-Host
       OutputScriptHeader
+      Write-Host $analyzeOnly
     
       # Ask for path
       $workingFolder = Set-Path


### PR DESCRIPTION
Use can add the flag `-analyzeOnly` to only analyze the specified path. The script will analyze but not modify any file.