### PR TITLE
Control of folder and backup images

### DIFF
--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -55,7 +55,7 @@ function AutoAnalyzeFiles {
         OutputImageAnalysisResult "folderJPG_notFound"
         OutputImageAnalysisResult "backupJPG_notFound"
         OutputImageAnalysisResult "restoreFailed"
-        # TODO: Append the folder path to an output file
+        "$(Get-Date) | No folder.jpg or backup.jpg | $($folderPath)`n" >> "$($workingFolder)\output.txt"
       }
       "True-False" {
         OutputImageAnalysisResult "folderJPG_present"

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -43,8 +43,8 @@ function AutoAnalyzeFiles {
 
     # Control of folder.jpg and backup.jpg
     Write-Host " Analyzing images ... " -Background Yellow -Foreground Black
-    $folderJPGpresence = Test-Path -Path "$($folderPath)/folder.jpg"
-    $backupJPGpresence = Test-Path -Path "$($folderPath)/backup.jpg"
+    $folderJPGpresence = Test-Path -Path "$($folderPath)\folder.jpg"
+    $backupJPGpresence = Test-Path -Path "$($folderPath)\backup.jpg"
 
     switch ("$($folderJPGpresence)-$($backupJPGpresence)") {
       "True-True" {

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -60,7 +60,8 @@ function AutoAnalyzeFiles {
       "True-False" {
         OutputImageAnalysisResult "folderJPG_present"
         OutputImageAnalysisResult "backupJPG_notFound"
-        # TODO: Create backup.jpg from folder.jpg
+        # Create backup.jpg from folder.jpg
+        Copy-Item -Path "$($folderPath)\folder.jpg" -Destination "$($folderPath)\backup.jpg"
         OutputImageAnalysisResult "backupJPG_restored"
       }
       "False-True" {

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -67,7 +67,8 @@ function AutoAnalyzeFiles {
       "False-True" {
         OutputImageAnalysisResult "folderJPG_notFound"
         OutputImageAnalysisResult "backupJPG_present"
-        # TODO: Restore folder.jpg from backup.jpg
+        # Create backup.jpg from folder.jpg
+        Copy-Item -Path "$($folderPath)\backup.jpg" -Destination "$($folderPath)\folder.jpg"
         OutputImageAnalysisResult "folderJPG_restored"
       }
       Default {}

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -55,7 +55,7 @@ function AutoAnalyzeFiles {
         OutputImageAnalysisResult "folderJPG_notFound"
         OutputImageAnalysisResult "backupJPG_notFound"
         OutputImageAnalysisResult "restoreFailed"
-        "$(Get-Date) | No folder.jpg or backup.jpg | $($folderPath)`n" >> "$($workingFolder)\MusicAnalyzerOutput.txt"
+        "$(Get-Date) | No folder.jpg or backup.jpg | $($folderPath)" >> "$($workingFolder)\MusicAnalyzerOutput.txt"
       }
       "True-False" {
         OutputImageAnalysisResult "folderJPG_present"
@@ -76,6 +76,7 @@ function AutoAnalyzeFiles {
     Write-Host ""
 
     # Control of normalization
+    Write-Host " Analyzing volume ... " -Background Yellow -Foreground Black
     if ($fileNumber -gt 0 ) {
       # Initialize file progress bar variables
       $fileCompleted = 0
@@ -84,7 +85,6 @@ function AutoAnalyzeFiles {
     
       # Analyzing-Block
       $volumeAnalysis = [System.Collections.ArrayList]::new()
-      Write-Host " Analyzing volume ... " -Background Yellow -Foreground Black
       $fileList | ForEach-Object {
         # Variables for the file
         $currentFile = @{

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -55,7 +55,7 @@ function AutoAnalyzeFiles {
         OutputImageAnalysisResult "folderJPG_notFound"
         OutputImageAnalysisResult "backupJPG_notFound"
         OutputImageAnalysisResult "restoreFailed"
-        "$(Get-Date) | No folder.jpg or backup.jpg | $($folderPath)`n" >> "$($workingFolder)\output.txt"
+        "$(Get-Date) | No folder.jpg or backup.jpg | $($folderPath)`n" >> "$($workingFolder)\MusicAnalyzerOutput.txt"
       }
       "True-False" {
         OutputImageAnalysisResult "folderJPG_present"

--- a/1.0.0/private/AutoAnalyzeFiles.ps1
+++ b/1.0.0/private/AutoAnalyzeFiles.ps1
@@ -41,6 +41,39 @@ function AutoAnalyzeFiles {
     $fileList = Get-ChildItem -Path $folderPath -File
     $fileNumber = $fileList.Count
 
+    # Control of folder.jpg and backup.jpg
+    Write-Host " Analyzing images ... " -Background Yellow -Foreground Black
+    $folderJPGpresence = Test-Path -Path "$($folderPath)/folder.jpg"
+    $backupJPGpresence = Test-Path -Path "$($folderPath)/backup.jpg"
+
+    switch ("$($folderJPGpresence)-$($backupJPGpresence)") {
+      "True-True" {
+        OutputImageAnalysisResult "folderJPG_present"
+        OutputImageAnalysisResult "backupJPG_present"
+      }
+      "False-False" {
+        OutputImageAnalysisResult "folderJPG_notFound"
+        OutputImageAnalysisResult "backupJPG_notFound"
+        OutputImageAnalysisResult "restoreFailed"
+        # TODO: Append the folder path to an output file
+      }
+      "True-False" {
+        OutputImageAnalysisResult "folderJPG_present"
+        OutputImageAnalysisResult "backupJPG_notFound"
+        # TODO: Create backup.jpg from folder.jpg
+        OutputImageAnalysisResult "backupJPG_restored"
+      }
+      "False-True" {
+        OutputImageAnalysisResult "folderJPG_notFound"
+        OutputImageAnalysisResult "backupJPG_present"
+        # TODO: Restore folder.jpg from backup.jpg
+        OutputImageAnalysisResult "folderJPG_restored"
+      }
+      Default {}
+    }
+    Write-Host ""
+
+    # Control of normalization
     if ($fileNumber -gt 0 ) {
       # Initialize file progress bar variables
       $fileCompleted = 0

--- a/1.0.0/private/CleanBackups.ps1
+++ b/1.0.0/private/CleanBackups.ps1
@@ -20,7 +20,6 @@ function CleanBackups {
     $userChoice = Read-Host "$($Emojis["question"]) Would you like to delete *.backup files? All the subdirectories will be also cleaned! [s/n]"
     switch ($userChoice) {
       's' {
-        Write-Host ""
         CleanFiles $workingFolder 
       }
       'n' { Read-Host " >> Ok, press enter to exit" }

--- a/1.0.0/private/Outputs.ps1
+++ b/1.0.0/private/Outputs.ps1
@@ -206,3 +206,21 @@ function OutputRestoreResult {
     Default {}
   }
 }
+function OutputImageAnalysisResult {
+  [CmdletBinding(DefaultParameterSetName)]
+  Param (
+    [Parameter(Mandatory = $true)]
+    [String]$Value
+  )
+    
+  switch ($Value) {
+    'folderJPG_present' { Write-Host " $($Emojis["check"]) folder.jpg detected" }
+    'backupJPG_present' { Write-Host " $($Emojis["check"]) backup.jpg detected" }
+    'folderJPG_notFound' { Write-Host " $($Emojis["warning"]) folder.jpg not found" }
+    'backupJPG_notFound' { Write-Host " $($Emojis["warning"]) backup.jpg not found" }
+    'folderJPG_restored' { Write-Host " $($Emojis["check"]) folder.jpg restored from backup" }
+    'backupJPG_restored' { Write-Host " $($Emojis["check"]) backup.jpg created" }
+    'restoreFailed' { Write-Host " $($Emojis["error"]) You need to manually correct the images here" }
+    Default {}
+  }
+}


### PR DESCRIPTION
The script now controls if `folder.jpg` and `backup.jpg` exist. If not, it try to create or restore them.

If there's no way to restore them, it outputs the folder path in a file, so that the user can later manually correct this errors.